### PR TITLE
Overrid -help flag to be helpful instead of blank

### DIFF
--- a/jsonpp.go
+++ b/jsonpp.go
@@ -14,6 +14,19 @@ import (
 var newline = []uint8("\n")
 
 func main() {
+
+	var help = flag.Bool("help", false, "help")
+	flag.Parse()
+	if *help {
+		cmd := os.Args[0]
+		if cmd[0:2] == "./" {
+			cmd = cmd[2:]
+		}
+		fmt.Fprintf(os.Stderr, "Usage: "+cmd+" [file]"+"\n")
+		fmt.Fprintf(os.Stderr, "   or: $COMMAND | "+cmd+"\n")
+		os.Exit(0)
+	}
+
 	bufIn := bufio.NewReader(fileFromArguments())
 	lastLine := []uint8("")
 


### PR DESCRIPTION
Go provides a default -help flag, which in this case printed nothing because there are no flags. This change will override that flag (-help and --help) by providing a more helpful message. 

Sample:

```
[moonstone jsonpp] (master●) $ ./jsonpp --help
Usage: jsonpp [file]
   or: $COMMAND | jsonpp
```
