### PR TITLE
Added support for more than one filename so multiple JSON files can be pretty printed quickly.

### DIFF
--- a/jsonpp.go
+++ b/jsonpp.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -26,21 +25,52 @@ func main() {
 		os.Exit(0)
 	}
 
-	bufIn := bufio.NewReader(fileFromArguments())
+	var exitStatus = 0
+	if len(flag.Args()) > 0 {
+		for _, filename := range flag.Args() {
+			file, err := os.OpenFile(filename, os.O_RDONLY, 0)
+			if err != nil {
+				printError(err)
+				exitStatus = 1
+				continue
+			}
+			defer file.Close()
+
+			status := processFile(file)
+			if status > 0 {
+				exitStatus = status
+			}
+		}
+	} else {
+		status := processFile(os.Stdin)
+		if status > 0 {
+			exitStatus = status
+		}
+	}
+	os.Exit(exitStatus)
+}
+
+func processFile(fn *os.File) int {
+	bufIn := bufio.NewReader(fn)
 	arr := make([]byte, 0, 1024*1024)
 	buf := bytes.NewBuffer(arr)
 	lineNum := int64(1)
 	for {
 		lastLine, err := bufIn.ReadBytes('\n')
 		if err != nil && err != io.EOF {
-			genericError(err)
+			printError(err)
+			return 2
 		}
 
 		if err == io.EOF && len(lastLine) == 0 {
 			break
 		}
 
-		indentAndPrint(buf, lastLine, lineNum)
+		status := indentAndPrint(buf, lastLine, lineNum)
+		if status > 0 {
+			return status
+		}
+
 		buf.Reset()
 		lineNum += 1
 
@@ -48,14 +78,19 @@ func main() {
 			break
 		}
 	}
+
+	return 0
 }
 
-func indentAndPrint(buf *bytes.Buffer, js []byte, lineNum int64) {
+func indentAndPrint(buf *bytes.Buffer, js []byte, lineNum int64) int {
 	jsErr := json.Indent(buf, js, "", "  ")
 	if jsErr != nil {
 		malformedJSON(jsErr, js, lineNum)
+		return 1
 	}
 	os.Stdout.Write(buf.Bytes())
+
+	return 0
 }
 
 func malformedJSON(jsErr error, js []uint8, lineNum int64) {
@@ -84,29 +119,9 @@ func malformedJSON(jsErr error, js []uint8, lineNum int64) {
 	} else {
 		fmt.Fprintf(os.Stderr, "ERROR: Broken json on line %d: %s\n", lineNum, jsErr)
 	}
-
-	os.Exit(1)
 }
 
-func fileFromArguments() *os.File {
-	args := flag.Args()
-	if len(args) > 1 {
-		msg := fmt.Sprintf("only specify 0 or 1 files in the arguments, not %d\n", len(args))
-		genericError(errors.New(msg))
-	}
-	if len(args) == 0 {
-		return os.Stdin
-	}
-
-	file, err := os.OpenFile(args[0], os.O_RDONLY, 0)
-	if err != nil {
-		genericError(err)
-	}
-	return file
-}
-
-func genericError(err error) {
+func printError(err error) {
 	os.Stdout.Sync()
-	fmt.Fprintf(os.Stderr, "ERROR: %s", err)
-	os.Exit(2)
+	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 }


### PR DESCRIPTION
   Examples:
- jsonpp *
- jsonpp a.json b.json

If there is an error with a file, a warning will be printed, but processing will continue to the next file.
